### PR TITLE
More par repacking fixes

### DIFF
--- a/ShinRyuModManager-CE/ParRepacker.cs
+++ b/ShinRyuModManager-CE/ParRepacker.cs
@@ -262,7 +262,7 @@ public static class ParRepacker {
     }
     
     private static Node SearchParNode(Node node, string path) {
-        var paths = path.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+        var paths = path.Split(NodeSystem.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
         
         return paths.Length == 0 
             ? null 

--- a/ShinRyuModManager-CE/ShinRyuModManager-CE.csproj
+++ b/ShinRyuModManager-CE/ShinRyuModManager-CE.csproj
@@ -10,7 +10,7 @@
         <Configurations>Debug;Release</Configurations>
         <Platforms>x64</Platforms>
         <IsPackable>false</IsPackable>
-        <AssemblyVersion>1.1.5</AssemblyVersion>
+        <AssemblyVersion>1.1.6</AssemblyVersion>
         <ApplicationIcon>UserInterface\Assets\Icons\SRMM_icon.ico</ApplicationIcon>
     </PropertyGroup>
 

--- a/ShinRyuModManager-CE/UserInterface/Assets/changelog.md
+++ b/ShinRyuModManager-CE/UserInterface/Assets/changelog.md
@@ -1,3 +1,8 @@
+> ### **%{color:orange} Version 1.1.6 %** ###
+* Fixed more issues with par repacking
+
+---
+
 > ### **%{color:orange} Version 1.1.5 %** ###
 * Ported over changes from SRMM 4.6.4
 * Fixed issue with archive concurrency

--- a/ShinRyuModManager-CE/Utils.cs
+++ b/ShinRyuModManager-CE/Utils.cs
@@ -3,6 +3,7 @@ using System.Text;
 using SharpCompress.Common;
 using SharpCompress.Readers;
 using Utils;
+using Yarhl.FileSystem;
 
 namespace ShinRyuModManager;
 
@@ -15,7 +16,7 @@ public static class Utils {
     }
 
     public static string NormalizeToNodePath(string path) {
-        return NormalizeSeparator(path, '/');
+        return NormalizeSeparator(path, NodeSystem.PathSeparator.ToCharArray()[0]);
     }
 
     public static string GetAppVersion() {


### PR DESCRIPTION
- Use `NodeSystem.PathSeparator` instead of whatever the system uses