### PR TITLE
Added partial support for RebuildMLO on Linux

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -46,7 +46,7 @@ jobs:
           version: "5.0.0-beta2"
 
       - name: Setup MSVC
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c # v4.0.0
       
       - name: Generate VS Project
         working-directory: external/parless

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Setup MSVC
         uses: TheMrMilchmann/setup-msvc-dev@79dac248aac9d0059f86eae9d8b5bfab4e95e97c # v4.0.0
+        with:
+          arch: x64
       
       - name: Generate VS Project
         working-directory: external/parless

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -92,7 +92,7 @@ jobs:
         with: 
           path: '${{ runner.temp }}/external'
           
-      - name: Download dinput and winmm
+      - name: Download version.dll
         run: |
           curl -L https://github.com/SRMM-Studio/srmm-distrib/raw/refs/heads/main/Native/version.dll -o $RUNNER_TEMP/external/version.dll
       

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:
-          repository: SRMM-Studio/YakuzaParless
+          repository: TheTrueColonel/YakuzaParless # Migrate to "SRMM-Studio/YakuzaParless" later
           path: external/parless
           submodules: recursive
 
@@ -97,7 +97,7 @@ jobs:
         
       - name: Create Draft Release
         id: create_release
-        uses: ncipollo/release-action@b7eabc95ff50cbeeedec83973935c8f306dfcd0b # v1.20
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21
         with:
           tag: "v${{ env.PR_TAG }}"
           name: ${{ env.PR_NAME }}

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -29,6 +29,16 @@ jobs:
           repository: TheTrueColonel/YakuzaParless # Migrate to "SRMM-Studio/YakuzaParless" later
           path: external/parless
           submodules: recursive
+          
+      - name: Verify Submodules
+        working-directory: external/parless
+        run: git submodule status --recursive
+        
+      - name: Verify Submodule Contents
+        working-directory: external/parless
+        run: |
+          dir source\Utils
+          dir source\minhook
 
       - name: Install Premake 5
         uses: abel0b/setup-premake@b80dc6f70e8ab159fb854bdadbeb1a53cfc28723 # v2.4

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Here will be listed the known differences and issues that the port brings.
 - Opening the CLI version with `Left-CTRL` doesn't work as there's no good way to detect this on all supported platforms.
 - Console output doesn't currently work on Windows.
 - MessageBoxes are different. This is strictly because Avalonia [doesn't have native support](https://docs.avaloniaui.net/docs/basics/user-interface/messagebox) yet, but it does look to be planned for the next major release.
-- On Linux you must run in CLI mode, or press the "Save mod list" button for the `.mlo` to generate. This is because Parless only searches for the Windows `.exe`.
 
 # Credits
 Original project by [SutandoTsukai181](https://github.com/SutandoTsukai181).

--- a/ShinRyuModManager-CE/Program.cs
+++ b/ShinRyuModManager-CE/Program.cs
@@ -71,6 +71,12 @@ public static class Program {
                                           .WriteTo.Async(a => a.File(new JsonFormatter(renderMessage: true), errorLogsPath, rollingInterval: RollingInterval.Day)))
                      .CreateLogger();
 
+#if LINUX_SLIM
+        // Slim versions of Linux need to have .NET 10 installed to run and Proton/Wine makes that
+        // annoying to find to get this working. Temporarily disabled.
+        RebuildMlo = false;
+#endif
+        
         HandleLoader();
         
         // Check if there are any args, if so, run in CLI mode

--- a/ShinRyuModManager-CE/Program.cs
+++ b/ShinRyuModManager-CE/Program.cs
@@ -71,10 +71,6 @@ public static class Program {
                                           .WriteTo.Async(a => a.File(new JsonFormatter(renderMessage: true), errorLogsPath, rollingInterval: RollingInterval.Day)))
                      .CreateLogger();
 
-        if (!OperatingSystem.IsWindows()) {
-            IsRebuildMloSupported = false;
-        }
-
         HandleLoader();
         
         // Check if there are any args, if so, run in CLI mode

--- a/ShinRyuModManager-CE/ShinRyuModManager-CE.csproj
+++ b/ShinRyuModManager-CE/ShinRyuModManager-CE.csproj
@@ -14,7 +14,7 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         
         <!-- Versioning -->
-        <AssemblyVersion>1.4.12</AssemblyVersion>
+        <AssemblyVersion>1.5.0</AssemblyVersion>
         <VersionPrefix>$(AssemblyVersion)</VersionPrefix>
         <AssemblyTitle>ShinRyuModManager-CE</AssemblyTitle>
         <Company>SRMM Studio</Company>

--- a/ShinRyuModManager-CE/ShinRyuModManager-CE.csproj
+++ b/ShinRyuModManager-CE/ShinRyuModManager-CE.csproj
@@ -33,6 +33,10 @@
         <DebugType>embedded</DebugType>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Configuration)' == 'Release' And '$(BuildSuffix)' == 'linux-slim'">
+        <DefineConstants>$(DefineConstants);LINUX_SLIM</DefineConstants>
+    </PropertyGroup>
+
     <ItemGroup>
         <ProjectReference Include="..\CpkTools\CpkTools.csproj" />
         <ProjectReference Include="..\ParLibrary\ParLibrary.csproj" />

--- a/ShinRyuModManager-CE/UserInterface/Assets/changelog.md
+++ b/ShinRyuModManager-CE/UserInterface/Assets/changelog.md
@@ -1,4 +1,9 @@
-> ### **%{color:gold} Version 1.4.12 %** ###
+> ### **%{color:gold} Version 1.5.0 %** ###
+* Enabled RebuildMLO for Linux users
+
+---
+
+> ### **%{color:orange} Version 1.4.12 %** ###
 * Fixed bug in Y0 mod upgrader method
 
 ---

--- a/ShinRyuModManager-CE/UserInterface/Assets/changelog.md
+++ b/ShinRyuModManager-CE/UserInterface/Assets/changelog.md
@@ -1,5 +1,6 @@
 > ### **%{color:gold} Version 1.5.0 %** ###
-* Enabled RebuildMLO for Linux users
+* Partial RebuildMLO support for Linux users
+  * `linux` "non-slim" users only, until a workaround is found for `linux-slim` users
 
 ---
 


### PR DESCRIPTION
- Partial support for RebuildMLO on Linux
  - `linux-slim` users are still unable to use it because of complications with Proton/Wine and needing to find the .NET 10 runtime